### PR TITLE
Assert that not both plasma are enabled

### DIFF
--- a/nixos/plasma6.nix
+++ b/nixos/plasma6.nix
@@ -34,6 +34,13 @@ in {
   };
 
   config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.enable -> !config.services.xserver.desktopManager.plasma5.enable;
+        message = "Cannot enable plasma5 and plasma6 at the same time!";
+      }
+    ];
+
     qt.enable = true;
     environment.systemPackages = with kdePackages; let
       requiredPackages = [


### PR DESCRIPTION
I created a specialisation and inherited the config which had both plasma turned on and it failed with 

```
┃        error: The option `specialisation.plasma6.configuration.environment.sessionVariables.KPACKAGE_DEP_RESOLVERS_PATH' has conflicting definition values:
┃        - In `/nix/store/2kncqm75gqnxkwhh51av36fs4daws7gh-source/flake.nix': "/nix/store/2xcgz45yzqr4y5b2vinp0x1mxihz34ix-frameworkintegration-5.245.0/libexec/kf6/kpackagehandlers"
┃        - In `/nix/store/2kncqm75gqnxkwhh51av36fs4daws7gh-source/nixos/modules/services/x11/desktop-managers/plasma5.nix': "/nix/store/mh91n84z55pqddw0853m6wkyka9z7nrs-frameworkintegration…
┃        Use `lib.mkForce value` or `lib.mkDefault value` to change the priority on any of these definitions.
```