### PR TITLE
kio: fix kpasswdserver service name

### DIFF
--- a/pkgs/kde/frameworks/kio/default.nix
+++ b/pkgs/kde/frameworks/kio/default.nix
@@ -1,5 +1,6 @@
 {
   mkKdeDerivation,
+  fetchpatch,
   qt5compat,
   qttools,
   acl,
@@ -8,9 +9,15 @@
 mkKdeDerivation {
   pname = "kio";
 
-  # Remove hardcoded smbd search path
-  # FIXME(later): discuss with upstream?
-  patches = [./0001-Remove-impure-smbd-search-path.patch];
+  patches = [
+    # Remove hardcoded smbd search path
+    # FIXME(later): discuss with upstream?
+    ./0001-Remove-impure-smbd-search-path.patch
+    (fetchpatch {
+      url = "https://invent.kde.org/frameworks/kio/-/commit/146db4f79413b3a904e5ff252ca61bb09e17be2c.diff";
+      hash = "sha256-6tDHmGbRweauJJY8bNQMmRZKHQplhvyMN6On1SstXgM=";
+    })
+  ];
 
   extraBuildInputs = [qt5compat qttools acl attr];
 }


### PR DESCRIPTION
Apply patch from [upstream PR](https://invent.kde.org/frameworks/kio/-/merge_requests/1497) to make kpasswdserver clients actually use the right service name.