### PR TITLE
Filter licenses that are null to fix check meta, remove usage of aliases

### DIFF
--- a/pkgs/kde/lib/mk-kde-derivation.nix
+++ b/pkgs/kde/lib/mk-kde-derivation.nix
@@ -106,7 +106,7 @@ in
         {
           description = projectInfo.${pname}.description;
           homepage = "https://invent.kde.org/${projectInfo.${pname}.repo_path}";
-          license = map (l: licensesBySpdxId.${l}) licenseInfo.${pname};
+          license = lib.filter (l: l != null) (map (l: licensesBySpdxId.${l}) licenseInfo.${pname});
         }
         // meta;
     };

--- a/pkgs/kde/plasma/kinfocenter/default.nix
+++ b/pkgs/kde/plasma/kinfocenter/default.nix
@@ -5,7 +5,7 @@
   qttools,
   xdpyinfo,
   systemsettings,
-  libusb,
+  libusb1,
 }:
 mkKdeDerivation {
   pname = "kinfocenter";
@@ -25,5 +25,5 @@ mkKdeDerivation {
     ln -sf ${systemsettings}/bin/systemsettings $out/bin/kinfocenter
   '';
 
-  extraBuildInputs = [libusb];
+  extraBuildInputs = [libusb1];
 }


### PR DESCRIPTION
```
       error: Package ‘kcoreaddons-5.246.0’ in /nix/store/6mgi93p70j9mk0zkx5v6c92wnvai2gif-source/pkgs/kde/lib/mk-kde-derivation.nix:107 has an invalid meta attrset:
         - key 'meta.license' has invalid value; expected (attribute set of anything) or string or list of ((attribute set of anything) or string), got
```